### PR TITLE
Remove postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "prepublish": "tsc",
-    "postinstall": "tsc",
     "tsc": "tsc"
   },
   "repository": {


### PR DESCRIPTION
postinstall should not be needed as no other ng2-module / library whatsoever uses it and it is creating problems where the whole application can not be deployed to Heroku, maybe other PaaS services too...

Also see #10